### PR TITLE
Add Zalgo text protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 venv/
 FIDO.log
 *.sqlite
+*.pyc

--- a/modules/channelprotectionhandler.py
+++ b/modules/channelprotectionhandler.py
@@ -1,7 +1,8 @@
 import fido
 from modules.channelprotections import masshighlighting
+from modules.channelprotections import zalgoprotection
 
-protections = [masshighlighting.on_message]
+protections = [masshighlighting.on_message, zalgoprotection.on_message]
 
 
 async def handle_message(bot: fido, channel: str, sender:str, message: str):

--- a/modules/channelprotections/zalgoprotection.py
+++ b/modules/channelprotections/zalgoprotection.py
@@ -1,0 +1,46 @@
+from typing import List
+from models import config, SessionManager
+
+import codecs
+import fido
+import math
+import re
+import sys
+import unicodedata
+
+ZALGO_CHAR_CATEGORIES = ['Mn', 'Me']
+THRESHOLD = 0.5
+PERCENTILE = 0.75
+
+def percentile(scores: list):
+    if len(scores) == 0:
+        return 0
+    
+    scores = sorted(scores)
+    i = len(scores) * PERCENTILE - 0.5
+    f = math.floor(i)
+    if abs(f - i) < sys.float_info.epsilon:
+        return scores[f]
+    
+    fract = i - f
+    return (1 - fract) * scores[f] + fract * scores[min(f + 1, len(scores) - 1)]
+
+
+def is_zalgo(s):
+    if len(s) == 0:
+        return False
+    word_scores = []
+    for word in s.split():
+        cats = [unicodedata.category(c) for c in word]
+        score = sum([cats.count(banned) for banned in ZALGO_CHAR_CATEGORIES]) / len(word)
+        word_scores.append(score)
+    total_score = percentile(word_scores)
+    return total_score > THRESHOLD
+
+
+async def on_message(bot: fido, channel: str, sender: str, message: str):
+    session = SessionManager().session
+    kick_reason: str = session.query(config.Config).filter_by(module='channelprotection', key='reason')[0].value
+
+    if is_zalgo(unicodedata.normalize('NFD', message)):
+      await bot.kick(channel, sender, kick_reason)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sqlalchemy
 requests
 pydle==0.9.1
+pyopenssl
 nexmo


### PR DESCRIPTION
This recreates the anti-zalgo protection that the previous version of FIDO had. It uses much the same algorithm as the original version, adapted to fit python. Tested with varying levels of "zalgo-ificiation" as well as ensuring that languages with diacritical marks do not get caught in the crossfire.